### PR TITLE
Improve Browsing Experience

### DIFF
--- a/src/main/java/it/garambo/retrosearch/browse/model/HtmlPageExtra.java
+++ b/src/main/java/it/garambo/retrosearch/browse/model/HtmlPageExtra.java
@@ -1,3 +1,0 @@
-package it.garambo.retrosearch.browse.model;
-
-public abstract class HtmlPageExtra {}

--- a/src/main/java/it/garambo/retrosearch/browse/model/ParsedHtmlPage.java
+++ b/src/main/java/it/garambo/retrosearch/browse/model/ParsedHtmlPage.java
@@ -3,4 +3,4 @@ package it.garambo.retrosearch.browse.model;
 import lombok.Builder;
 
 @Builder
-public record ParsedHtmlPage(String title, String content, HtmlPageExtra extra) {}
+public record ParsedHtmlPage(String title, String htmlContent) {}

--- a/src/main/java/it/garambo/retrosearch/browse/parser/ModernHtmlParser.java
+++ b/src/main/java/it/garambo/retrosearch/browse/parser/ModernHtmlParser.java
@@ -4,8 +4,13 @@ import it.garambo.retrosearch.browse.model.ParsedHtmlPage;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import net.dankito.readability4j.Article;
+import org.jsoup.nodes.Document;
 
 public interface ModernHtmlParser {
-
   ParsedHtmlPage parsePage(URI uri) throws IOException, URISyntaxException;
+
+  String cleanPage(String articleContent, boolean replacePageLinks);
+
+  Article parseArticle(URI uri, Document document);
 }

--- a/src/main/java/it/garambo/retrosearch/browse/parser/ModernHtmlParserImpl.java
+++ b/src/main/java/it/garambo/retrosearch/browse/parser/ModernHtmlParserImpl.java
@@ -5,8 +5,14 @@ import it.garambo.retrosearch.http.HttpService;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 import net.dankito.readability4j.Article;
 import net.dankito.readability4j.Readability4J;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist;
+import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,12 +23,43 @@ public class ModernHtmlParserImpl implements ModernHtmlParser {
 
   @Override
   public ParsedHtmlPage parsePage(URI uri) throws IOException, URISyntaxException {
-    String document = httpService.get(uri);
-    Article article = new Readability4J(uri.toASCIIString(), document).parse();
+    Document document = Jsoup.parse(httpService.get(uri));
+    Article article = parseArticle(uri, document);
+    String title = article.getTitle();
 
     return ParsedHtmlPage.builder()
-        .title(article.getTitle())
-        .content(article.getTextContent())
+        .title(title)
+        .htmlContent(cleanPage(article.getContent(), true))
         .build();
+  }
+
+  public String cleanPage(String articleContent, boolean replacePageLinks) {
+    String safePage =
+        Jsoup.clean(
+            Objects.requireNonNull(articleContent),
+            Safelist.basic()
+                .addProtocols("a", "href", "http", "https")
+                .preserveRelativeLinks(true));
+
+    if (!replacePageLinks) {
+      return safePage;
+    }
+
+    return replacePageLinks(safePage).html();
+  }
+
+  public Element replacePageLinks(String articleContent) {
+    Element document = Jsoup.parse(articleContent);
+    Elements links = Objects.requireNonNull(document).select("a");
+    for (Element element : links) {
+      String originalHref = element.attr("abs:href");
+      element.attr("href", "/browse?url=" + originalHref);
+    }
+    return document;
+  }
+
+  @Override
+  public Article parseArticle(URI uri, Document document) {
+    return new Readability4J(uri.toASCIIString(), document).parse();
   }
 }

--- a/src/main/java/it/garambo/retrosearch/controller/GenericErrorController.java
+++ b/src/main/java/it/garambo/retrosearch/controller/GenericErrorController.java
@@ -12,5 +12,4 @@ public class GenericErrorController implements ErrorController {
   public String genericError(Model model) {
     return "error";
   }
-
 }

--- a/src/main/java/it/garambo/retrosearch/ddg/client/DDGClientImpl.java
+++ b/src/main/java/it/garambo/retrosearch/ddg/client/DDGClientImpl.java
@@ -2,7 +2,7 @@ package it.garambo.retrosearch.ddg.client;
 
 import it.garambo.retrosearch.ddg.model.ResultEntry;
 import it.garambo.retrosearch.ddg.model.SearchResults;
-import it.garambo.retrosearch.ddg.scraper.JsoupScraper;
+import it.garambo.retrosearch.ddg.scraper.DDGScraper;
 import it.garambo.retrosearch.ddg.util.DDGConstants;
 import it.garambo.retrosearch.http.HttpService;
 import java.io.IOException;
@@ -18,7 +18,7 @@ public class DDGClientImpl implements DDGClient {
 
   @Autowired private HttpService httpService;
 
-  @Autowired private JsoupScraper jsoupScraper;
+  @Autowired private DDGScraper ddgScraper;
 
   @Override
   public SearchResults search(String query) throws IOException, URISyntaxException {
@@ -33,7 +33,7 @@ public class DDGClientImpl implements DDGClient {
             DDGConstants.REGION_PARAM_NAME, locale);
 
     String resultPage = httpService.get(URI.create(DDGConstants.BASE_URL), searchParams);
-    List<ResultEntry> resultEntryList = jsoupScraper.scrapeResults(resultPage);
+    List<ResultEntry> resultEntryList = ddgScraper.scrapeResults(resultPage);
 
     return SearchResults.builder()
         .query(query)

--- a/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraper.java
+++ b/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraper.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
-public interface Scraper {
+public interface DDGScraper {
   List<ResultEntry> scrapeResults(String html);
 
   Document getDocument(String html);

--- a/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraperConstants.java
+++ b/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraperConstants.java
@@ -1,4 +1,4 @@
-package it.garambo.retrosearch.ddg.util;
+package it.garambo.retrosearch.ddg.scraper;
 
 import lombok.Getter;
 

--- a/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraperImpl.java
+++ b/src/main/java/it/garambo/retrosearch/ddg/scraper/DDGScraperImpl.java
@@ -1,6 +1,6 @@
 package it.garambo.retrosearch.ddg.scraper;
 
-import static it.garambo.retrosearch.ddg.util.DDGScraperConstants.*;
+import static it.garambo.retrosearch.ddg.scraper.DDGScraperConstants.*;
 
 import it.garambo.retrosearch.ddg.model.ResultEntry;
 import java.net.MalformedURLException;
@@ -22,7 +22,7 @@ import org.springframework.util.ObjectUtils;
 
 @Slf4j
 @Service
-public class JsoupScraper implements Scraper {
+public class DDGScraperImpl implements DDGScraper {
 
   @Autowired UrlValidator urlValidator;
 

--- a/src/main/resources/templates/browse.html
+++ b/src/main/resources/templates/browse.html
@@ -11,7 +11,7 @@
 
 <h2>Showing content from <em th:text="${originalUrl}"></em> below:</h2>
 <h3 th:text="${parsedHtmlPage.title}"></h3>
-<p th:text="${parsedHtmlPage.content}"></p>
+<p th:utext="${parsedHtmlPage.htmlContent}"></p>
 
 </body>
 </html>

--- a/src/test/java/it/garambo/retrosearch/ddg/scraper/DDGDDGScraperImplTest.java
+++ b/src/test/java/it/garambo/retrosearch/ddg/scraper/DDGDDGScraperImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import it.garambo.retrosearch.ddg.model.ResultEntry;
-import it.garambo.retrosearch.ddg.util.DDGScraperConstants;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -27,15 +26,15 @@ import org.springframework.core.io.Resource;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
-public class JsoupScraperTest {
+public class DDGDDGScraperImplTest {
 
-  @Autowired Scraper scraper;
+  @Autowired DDGScraper DDGScraper;
 
   @Test
   void testScrapeResults(@Value("classpath:test_result.html") Resource testResultHtml)
       throws IOException {
     String content = testResultHtml.getContentAsString(Charset.defaultCharset());
-    List<ResultEntry> results = scraper.scrapeResults(content);
+    List<ResultEntry> results = DDGScraper.scrapeResults(content);
     assertNotNull(results);
     assertEquals(4, results.size());
 
@@ -53,7 +52,7 @@ public class JsoupScraperTest {
   void testScrapeResultsWithInvalidElement(
       @Value("classpath:test_result_invalid.html") Resource testResultHtml) throws IOException {
     String content = testResultHtml.getContentAsString(Charset.defaultCharset());
-    List<ResultEntry> results = scraper.scrapeResults(content);
+    List<ResultEntry> results = DDGScraper.scrapeResults(content);
     assertNotNull(results);
     assertEquals(1, results.size());
   }
@@ -62,7 +61,7 @@ public class JsoupScraperTest {
   void testGetDocument(@Value("classpath:test_result.html") Resource testResultHtml)
       throws IOException {
     String content = testResultHtml.getContentAsString(Charset.defaultCharset());
-    Document document = scraper.getDocument(content);
+    Document document = DDGScraper.getDocument(content);
 
     assertNotNull(document);
     Assertions.assertEquals("Test Page", document.title());
@@ -76,7 +75,7 @@ public class JsoupScraperTest {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_TITLE_CLASS_SELECTOR)))
         .thenReturn(queryResults);
 
-    String title = scraper.getEntryTitle(resultElement);
+    String title = DDGScraper.getEntryTitle(resultElement);
     assertEquals("Title", title);
   }
 
@@ -84,7 +83,7 @@ public class JsoupScraperTest {
   void testGetEntryTitleEmpty(@Mock Element resultElement) {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_TITLE_CLASS_SELECTOR)))
         .thenReturn(new Elements());
-    String title = scraper.getEntryTitle(resultElement);
+    String title = DDGScraper.getEntryTitle(resultElement);
     assertNull(title);
   }
 
@@ -97,7 +96,7 @@ public class JsoupScraperTest {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_TITLE_CLASS_SELECTOR)))
         .thenReturn(queryResults);
 
-    URI title = scraper.getEntryUri(resultElement);
+    URI title = DDGScraper.getEntryUri(resultElement);
     assertEquals(URI.create("http://github.com"), title);
   }
 
@@ -105,7 +104,7 @@ public class JsoupScraperTest {
   void testGetEntryUriEmpty(@Mock Element resultElement) throws MalformedURLException {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_TITLE_CLASS_SELECTOR)))
         .thenReturn(new Elements());
-    URI title = scraper.getEntryUri(resultElement);
+    URI title = DDGScraper.getEntryUri(resultElement);
     assertNull(title);
   }
 
@@ -121,7 +120,7 @@ public class JsoupScraperTest {
         assertThrows(
             MalformedURLException.class,
             () -> {
-              scraper.getEntryUri(resultElement);
+              DDGScraper.getEntryUri(resultElement);
             });
     assertEquals("Invalid url for entry, url: not-a-uri", expectedException.getMessage());
   }
@@ -134,7 +133,7 @@ public class JsoupScraperTest {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_DESCRIPTION_CLASS_SELECTOR)))
         .thenReturn(queryResults);
 
-    String description = scraper.getEntryDescription(resultElement);
+    String description = DDGScraper.getEntryDescription(resultElement);
     assertEquals("Description", description);
   }
 
@@ -142,7 +141,7 @@ public class JsoupScraperTest {
   void testGetEntryDescriptionEmpty(@Mock Element resultElement) {
     when(resultElement.select(eq(DDGScraperConstants.RESULT_DESCRIPTION_CLASS_SELECTOR)))
         .thenReturn(new Elements());
-    String description = scraper.getEntryDescription(resultElement);
+    String description = DDGScraper.getEntryDescription(resultElement);
     assertNull(description);
   }
 }


### PR DESCRIPTION
The Browsing functionality now better uses the capabilities offered by the Mozilla Readability implementation. Page links are replaced by relative URLs that allow to continue web browsing through RetroSearch