### PR TITLE
Configurable Encoding and HTML Version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:
-          arguments: -P${{ env.version }} build
+          arguments: -Pversion=${{ env.version }} build
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.2-testing
+0.3-testing

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ repositories {
 	mavenCentral()
 }
 
+springBoot {
+	buildInfo()
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/it/garambo/retrosearch/configuration/ApplicationSettings.java
+++ b/src/main/java/it/garambo/retrosearch/configuration/ApplicationSettings.java
@@ -1,0 +1,12 @@
+package it.garambo.retrosearch.configuration;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationSettings {
+
+  private HTMLVersion htmlVersion;
+  private String encoding;
+}

--- a/src/main/java/it/garambo/retrosearch/configuration/BeanConfig.java
+++ b/src/main/java/it/garambo/retrosearch/configuration/BeanConfig.java
@@ -1,8 +1,8 @@
 package it.garambo.retrosearch.configuration;
 
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -26,16 +26,19 @@ public class BeanConfig {
   }
 
   @Bean
-  public String defaultDocType() {
-    return "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">";
+  public ApplicationSettings applicationSettings(
+      @Value("${retrosearch.html.version:2.0}") String htmlVersionValue,
+      @Value("${retrosearch.encoding:UTF-8}") String encodingValue) {
+    return new ApplicationSettings(HTMLVersion.getByVersionName(htmlVersionValue), encodingValue);
   }
 
   @Bean
   public ThymeleafViewResolver thymeleafViewResolver(
-      @Autowired SpringTemplateEngine templateEngine) {
+      @Autowired SpringTemplateEngine templateEngine,
+      @Autowired ApplicationSettings applicationSettings) {
     ThymeleafViewResolver resolver = new ThymeleafViewResolver();
     resolver.setTemplateEngine(templateEngine);
-    resolver.setCharacterEncoding(StandardCharsets.ISO_8859_1.displayName());
+    resolver.setCharacterEncoding(applicationSettings.getEncoding());
     return resolver;
   }
 }

--- a/src/main/java/it/garambo/retrosearch/configuration/HTMLVersion.java
+++ b/src/main/java/it/garambo/retrosearch/configuration/HTMLVersion.java
@@ -1,0 +1,159 @@
+package it.garambo.retrosearch.configuration;
+
+import lombok.Getter;
+
+@Getter
+public enum HTMLVersion {
+  HTML_2_0("2.0", HTMLConstants.HTML2_0_DOC_TYPE, HTMLConstants.HTML2_0_TAGS),
+  HTML_3_2("3.2", HTMLConstants.HTML3_2_DOC_TYPE, HTMLConstants.HTML3_2_TAGS);
+
+  final String id;
+  final String docType;
+  final String[] allowedTags;
+
+  HTMLVersion(String id, String docType, String[] allowedTags) {
+    this.id = id;
+    this.docType = docType;
+    this.allowedTags = allowedTags;
+  }
+
+  public static HTMLVersion getByVersionName(String htmlVersion) {
+    if (htmlVersion.equals("2.0")) {
+      return HTMLVersion.HTML_2_0;
+    }
+
+    return HTMLVersion.HTML_3_2;
+  }
+
+  private static class HTMLConstants {
+
+    public static final String HTML2_0_DOC_TYPE =
+        "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">";
+    public static final String HTML3_2_DOC_TYPE =
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">";
+
+    public static final String[] HTML2_0_TAGS = {
+      "A",
+      "ADDRESS",
+      "B",
+      "BASE",
+      "BLOCKQUOTE",
+      "BODY",
+      "BR",
+      "CITE",
+      "CODE",
+      "DD",
+      "DIR",
+      "DL",
+      "DT",
+      "EM",
+      "FORM",
+      "H1",
+      "H2",
+      "H3",
+      "H4",
+      "H5",
+      "H6",
+      "HEAD",
+      "HR",
+      "HTML",
+      "I",
+      "IMG",
+      "INPUT",
+      "ISINDEX",
+      "KBD",
+      "LI",
+      "LINK",
+      "LISTING",
+      "MENU",
+      "META",
+      "NEXTID",
+      "OL",
+      "OPTION",
+      "P",
+      "PLAINTEXT",
+      "PRE",
+      "SAMP",
+      "SELECT",
+      "STRONG",
+      "TEXTAREA",
+      "TITLE",
+      "TT",
+      "UL",
+      "VAR",
+      "XMP"
+    };
+    public static final String[] HTML3_2_TAGS = {
+      "A",
+      "ADDRESS",
+      "APPLET",
+      "AREA",
+      "B",
+      "BASE",
+      "BASEFONT",
+      "BIG",
+      "BLOCKQUOTE",
+      "BODY",
+      "BR",
+      "CAPTION",
+      "CENTER",
+      "CITE",
+      "CODE",
+      "DD",
+      "DFN",
+      "DIR",
+      "DIV",
+      "DL",
+      "DT",
+      "EM",
+      "FONT",
+      "FORM",
+      "H1",
+      "H2",
+      "H3",
+      "H4",
+      "H5",
+      "H6",
+      "HEAD",
+      "HR",
+      "HTML",
+      "I",
+      "IMG",
+      "INPUT",
+      "ISINDEX",
+      "KBD",
+      "LI",
+      "LINK",
+      "LISTING",
+      "MAP",
+      "MENU",
+      "META",
+      "OL",
+      "OPTION",
+      "P",
+      "PARAM",
+      "PLAINTEXT",
+      "PRE",
+      "SAMP",
+      "SCRIPT",
+      "SELECT",
+      "SMALL",
+      "STRIKE",
+      "STRONG",
+      "STYLE",
+      "SUB",
+      "SUP",
+      "TABLE",
+      "TD",
+      "TEXTAREA",
+      "TH",
+      "TITLE",
+      "TR",
+      "TT",
+      "U",
+      "UL",
+      "VAR",
+      "XMP"
+    };
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 server.error.whitelabel.enabled=false
+
+retrosearch.encoding=UTF-8
+retrosearch.html.version=3.2

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -9,15 +9,22 @@
     <p>It provides the ability to search the Web using DuckDuckGo with a custom scraper that loads the first page of results and allows you to browse pages in plain text.</p>
     <p>In short, RetroSearch parses long and complex web pages and return them to your old computer's browser with three main features:</p>
     <ul>
-        <li>responses in simple markup, with tags from the <a href="https://www.w3.org/MarkUp/html-spec/html-spec_toc.html">HTML 2.0 standard</a> or earlier</li>
-        <li>ISO-8859-1 encoding of pages</li>
+        <li>responses in simple markup, with tags from the <a href="https://www.w3.org/MarkUp/html-spec/html-spec_toc.html">HTML 2.0 standard</a> or <a href="https://www.w3.org/TR/2018/SPSD-html32-20180315/">3.2</a></li>
+        <li>ISO-8859-1 or UTF-8 encoding of pages</li>
         <li>no images (except for not one, not two, but three horrible WordArt-style logos!)</li>
     </ul>
 
+    <h2>Privacy (retrosearch.org)</h2>
+    <p>No technical, first-party cookies are being used on this website and I plan to continue doing so.</p>
+    <p>Similarly, no analytics plugins, advertisements, social network integrations (such as widgets or share buttons) are present on this website. The lack of these will benefit you from not being tracked by third-parties.</p>
+
     <h2>Notes</h2>
-    <p>I am aiming to support HTML 2.0 - As of now, the homepage and the search page (and this one of course) are 100% compliant.</p>
-    <p>At the moment, when browsing the web with the browse feature, there might be some unsupported tags being returned. </p>
-    <p>Most retro browsers (such as Netscape 2+) shouldn't have breaking issues with them.</p>
+    <ul>
+        <li>I am aiming to support HTML 2.0 and HTML 3.2 - As of now, the homepage and the search page (and this one of course) are 100% compliant.</li>
+        <li>At the moment, when browsing the web with the browse feature, there might be some unsupported tags being returned. </li>
+        <li>Most retro browsers (such as Netscape 2+) shouldn't have breaking issues with them.</li>
+        <li>retrosearch.org is currently configured to use HTML 3.2 and UTF-8, if you want, you can deploy your own version locally and configure it to use HTML 2.0 or another encoding</li>
+    </ul>
 
     <h2>Open source software</h2>
 

--- a/src/main/resources/templates/fragments/doctype.html
+++ b/src/main/resources/templates/fragments/doctype.html
@@ -1,1 +1,1 @@
-<th:block th:utext="@{__${@defaultDocType}__}"></th:block>
+<th:block th:utext="@{__${@applicationSettings.htmlVersion.docType}__}"></th:block>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,3 +1,12 @@
-<br>
-<a href="/about"><b>RetroSearch</b></a> is an open source project built by <a href="/browse?url=https://garambo.it/about"> Vincenzo Garambone</a>
-<p>Search results from <a href="https://duckduckgo.com">DuckDuckGo</a></p>
+<p>
+<a href="/about"><b>RetroSearch</b></a> is an open source project built by <a href="/browse?url=https://garambo.it/about">@garambo</a>
+| Search results from <a href="https://duckduckgo.com">DuckDuckGo</a>
+</p>
+<code>
+    HTML:
+    <th:block th:utext="${__${@applicationSettings.htmlVersion.id}__}"></th:block>
+    | Encoding:
+    <th:block th:utext="@{__${@applicationSettings.encoding}__}"></th:block>
+    | Version:
+    <th:block th:utext="@{__${@buildProperties.version}__}"></th:block>
+</code>


### PR DESCRIPTION
Adding configurable HTML Version for the modern HTML parser and Encoding via Properties, as found in `application.properties`:

```
retrosearch.encoding=UTF-8
retrosearch.html.version=3.2
```

Depending on the chosen HTML version, the allowed tags used by the modern HTML parser will change.

Also, small layout updates, a small fix for the release build step (providing correct gradle version)